### PR TITLE
wrong default pip

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,11 +32,11 @@ wine cmd.exe /c 'wmic os get osarchitecture'
 echo -e '\033[0m'
 
 echo -e '\033[1;32m[*] Installing Python Requirements \033[0m'
-sudo pip install blessed
-sudo pip install pyasn1
-sudo pip install --force-reinstall prompt-toolkit==1.0.15
-sudo pip install netifaces
-sudo pip install requests
+sudo pip2 install blessed
+sudo pip2 install pyasn1
+sudo pip2 install --force-reinstall prompt-toolkit==1.0.15
+sudo pip2 install netifaces
+sudo pip2 install requests
 
 echo -e '\033[1;32m[*] Downloading Python27, Pywin32 and Pycrypto For Wine \033[0m'
 if [[ ! -d "~/.win32/drive_c/Python27/" || $reinstall -eq 1 ]]; then


### PR DESCRIPTION
Most systems will link pip to pip3, use pip2 to avoid errors.